### PR TITLE
Do not consume super().fields

### DIFF
--- a/sanic_openapi3/definitions.py
+++ b/sanic_openapi3/definitions.py
@@ -139,7 +139,7 @@ class Parameter(Definition):
 
     @property
     def fields(self):
-        values = super().fields
+        values = super().fields.copy()
 
         values['in'] = values.pop('location')
 


### PR DESCRIPTION
Instead of using the super fields directly, create a (shallow) copy to prevent
mutating the super's values.